### PR TITLE
Feature/csv export closed tickets

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,0 +1,17 @@
+class ExportsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :authorize_agent!
+
+  def tickets_csv
+    csv_data = CsvExporter.export_closed_tickets
+    send_data csv_data, filename: "closed_tickets_last_month.csv"
+  end
+
+  private
+
+  def authorize_agent!
+    unless current_user.agent?
+      redirect_to root_path, alert: "Access denied."
+    end
+  end
+end

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -1,7 +1,7 @@
 class SupportTicket < ApplicationRecord
   belongs_to :user
 
-  enum status: { open: 0, pending: 1, closed: 2 }
+  enum status: { open: 0, pending: 1, closed: 2 }, _suffix: true
   has_many_attached :attachments
   has_many :comments, dependent: :destroy
 

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -1,0 +1,22 @@
+require "csv"
+
+class CsvExporter
+  def self.export_closed_tickets
+    tickets = SupportTicket.closed.where("updated_at >= ?", 1.month.ago)
+
+    CSV.generate(headers: true) do |csv|
+      csv << [ "ID", "Title", "Description", "Status", "Customer Email", "Closed At" ]
+
+      tickets.includes(:user).find_each do |ticket|
+        csv << [
+          ticket.id,
+          ticket.title,
+          ticket.description,
+          ticket.status,
+          ticket.user.email,
+          ticket.updated_at
+        ]
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,10 @@
 Rails.application.routes.draw do
   post "/graphql", to: "graphql#execute"
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "/tickets/export.csv", to: "exports#tickets_csv"
+
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
   # root "posts#index"
 end


### PR DESCRIPTION
## Export closed support tickets from the past month as CSV

### This PR adds backend logic to generate and export a CSV of support tickets that have been closed within the last one month, as required in the project specification:

“Support agents should be able to export a CSV of closed tickets from the past one month.”

My Implementation includes:

1. `CsvExporter` service
A clean service object that fetches closed tickets updated within the last 30 days and generates a well-structured CSV file with headers:

  `ID`, `Title`, ` Description`, `Status`, `Customer Email`, `Closed At`

Scope conflict fix
Added` _suffix: true` to the `status` enum in `SupportTicket `to avoid method name clashes (e.g., with `open?`).

