### PR TITLE
Feature/devise auth routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,6 @@ gem "active_storage_validations"
 
 gem "devise-jwt"
 
-gem "dotenv-rails", groups: [:development, :test]
-
 # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
 gem "kamal", require: false
 
@@ -64,4 +62,6 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  gem "dotenv-rails"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "active_storage_validations"
 
 gem "devise-jwt"
 
+gem "dotenv-rails", groups: [:development, :test]
+
 # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
 gem "kamal", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "image_processing"
 
 gem "active_storage_validations"
 
+gem "devise-jwt"
+
 # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
 gem "kamal", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "thruster", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.14)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -401,6 +403,7 @@ DEPENDENCIES
   kamal
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-cors
   rails (~> 7.1.3)
   rspec-rails
   rubocop-rails-omakase

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,9 @@ GEM
       warden-jwt_auth (~> 0.10)
     diff-lcs (1.6.1)
     dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.1)
     dry-auto_inject (1.1.0)
       dry-core (~> 1.1)
@@ -419,6 +422,7 @@ DEPENDENCIES
   debug
   devise
   devise-jwt
+  dotenv-rails
   graphql
   image_processing
   kamal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,9 +111,22 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-jwt (0.12.1)
+      devise (~> 4.0)
+      warden-jwt_auth (~> 0.10)
     diff-lcs (1.6.1)
     dotenv (3.1.8)
     drb (2.2.1)
+    dry-auto_inject (1.1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -147,6 +160,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.12.0)
+    jwt (2.10.1)
+      base64
     kamal (2.5.3)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -373,6 +388,11 @@ GEM
     unicode-emoji (4.0.4)
     warden (1.2.9)
       rack (>= 2.0.9)
+    warden-jwt_auth (0.11.0)
+      dry-auto_inject (>= 0.8, < 2)
+      dry-configurable (>= 0.13, < 2)
+      jwt (~> 2.1)
+      warden (~> 1.2)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -398,6 +418,7 @@ DEPENDENCIES
   cancancan
   debug
   devise
+  devise-jwt
   graphql
   image_processing
   kamal

--- a/app/controllers/api/users/confirmations_controller.rb
+++ b/app/controllers/api/users/confirmations_controller.rb
@@ -1,0 +1,17 @@
+
+module Api
+    module Users
+        class ConfirmationsController < Devise::ConfirmationsController
+            respond_to :json
+
+            def show
+                self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+                if resource.errors.empty?
+                render json: { message: "Email confirmed successfully." }
+                else
+                render json: { error: resource.errors.full_messages }, status: :unprocessable_entity
+                end
+            end
+        end
+    end
+end

--- a/app/controllers/api/users/registrations_controller.rb
+++ b/app/controllers/api/users/registrations_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module Users
+    class RegistrationsController < Devise::RegistrationsController
+      respond_to :json
+
+      private
+
+      def respond_with(resource, _opts = {})
+        if resource.persisted?
+          render json: {
+            message: "Signed up successfully.",
+            user: {
+              id: resource.id,
+              email: resource.email,
+              name: resource.name,
+              role: resource.role,
+              created_at: resource.created_at,
+              updated_at: resource.updated_at
+            }
+          }, status: :created
+        else
+          render json: { errors: resource.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def sign_up_params
+        params.require(:user).permit(:email, :password, :password_confirmation, :name)
+      end
+    end
+  end
+end

--- a/app/controllers/api/users/sessions_controller.rb
+++ b/app/controllers/api/users/sessions_controller.rb
@@ -1,0 +1,47 @@
+module Api
+  module Users
+    class SessionsController < Devise::SessionsController
+      respond_to :json
+
+      def create
+        user = User.find_for_database_authentication(email: sign_in_params[:email])
+
+        if user&.valid_password?(sign_in_params[:password])
+
+          payload = Warden::JWTAuth::UserEncoder.new.call(user, :user, nil)
+          token = payload[0]
+
+          render json: {
+            message: "Logged in successfully.",
+            token: token,
+            user: {
+              id: user.id,
+              email: user.email,
+              name: user.name,
+              role: user.role,
+              created_at: user.created_at,
+              updated_at: user.updated_at
+            }
+          }, status: :ok
+        else
+          render json: { error: "Invalid email or password" }, status: :unauthorized
+        end
+      end
+
+
+      private
+
+      def sign_in_params
+        params.require(:user).permit(:email, :password)
+      end
+
+      def respond_to_on_destroy
+        if current_user
+          render json: { message: "Logged out successfully." }, status: :ok
+        else
+          render json: { message: "User has no active session." }, status: :unauthorized
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::API
+    include ActionController::Helpers
+    include ActionController::MimeResponds
+
+    before_action :configure_permitted_parameters, if: :devise_controller?
+
+    protected
+
+    def configure_permitted_parameters
+        devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+        devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+    end
 end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 class GraphqlController < ApplicationController
-  # If accessing from outside this domain, nullify the session
-  # This allows for outside API access while preventing CSRF attacks,
-  # but you'll have to authenticate your user separately
-  # protect_from_forgery with: :null_session
-
   def execute
     variables = prepare_variables(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      # Query context goes here, for example:
-      # current_user: current_user,
+      current_user: current_user
     }
-    result = SupportPlatformApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+
+    result = SupportPlatformApiSchema.execute(
+      query,
+      variables: variables,
+      context: context,
+      operation_name: operation_name
+    )
+
     render json: result
   rescue StandardError => e
     raise e unless Rails.env.development?
@@ -23,19 +24,26 @@ class GraphqlController < ApplicationController
 
   private
 
-  # Handle variables in form data, JSON body, or a blank value
+  def current_user
+    token = request.headers["Authorization"]&.split(" ")&.last
+    return nil if token.blank?
+
+    begin
+      payload = Warden::JWTAuth::TokenDecoder.new.call(token)
+      User.find_by(id: payload["sub"])
+    rescue JWT::DecodeError, ActiveRecord::RecordNotFound
+      nil
+    end
+  end
+
   def prepare_variables(variables_param)
     case variables_param
     when String
-      if variables_param.present?
-        JSON.parse(variables_param) || {}
-      else
-        {}
-      end
+      variables_param.present? ? JSON.parse(variables_param) : {}
     when Hash
       variables_param
     when ActionController::Parameters
-      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
+      variables_param.to_unsafe_hash
     when nil
       {}
     else
@@ -47,6 +55,9 @@ class GraphqlController < ApplicationController
     logger.error e.message
     logger.error e.backtrace.join("\n")
 
-    render json: { errors: [ { message: e.message, backtrace: e.backtrace } ], data: {} }, status: 500
+    render json: {
+      errors: [ { message: e.message, backtrace: e.backtrace } ],
+      data: {}
+    }, status: 500
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,7 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable
+         :recoverable, :rememberable, :validatable, :confirmable,
+         :jwt_authenticatable, jwt_revocation_strategy: Devise::JWT::RevocationStrategies::Null
 
   enum role: { customer: 0, agent: 1 }
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 
   enum role: { customer: 0, agent: 1 }
   validates :name, presence: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,8 @@ require "rails/all"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+Dotenv::Railtie.load if defined?(Dotenv)
+
 
 module SupportPlatformApi
   class Application < Rails::Application
@@ -25,17 +27,10 @@ module SupportPlatformApi
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
 
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
+
     config.api_only = true
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "http://localhost:4200"
+
+    resource "*",
+      headers: :any,
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -97,8 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth, :params_auth]
-
+  config.skip_session_storage = [:http_auth]
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX
   # requests for sign in and sign up, you need to get a new CSRF token
@@ -310,4 +309,14 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+  config.jwt do |jwt|
+    jwt.secret = ENV["DEVISE_JWT_SECRET_KEY"]
+    jwt.dispatch_requests = [
+      ['POST', %r{^/users/sign_in$}]
+    ]
+    jwt.revocation_requests = [
+      ['DELETE', %r{^/users/sign_out$}]
+    ]
+    jwt.expiration_time = 1.day.to_i
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage = [ :http_auth ]
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX
   # requests for sign in and sign up, you need to get a new CSRF token
@@ -312,10 +312,10 @@ Devise.setup do |config|
   config.jwt do |jwt|
     jwt.secret = ENV["DEVISE_JWT_SECRET_KEY"]
     jwt.dispatch_requests = [
-      ['POST', %r{^/users/sign_in$}]
+      [ "POST", %r{^/users/sign_in$} ]
     ]
     jwt.revocation_requests = [
-      ['DELETE', %r{^/users/sign_out$}]
+      [ "DELETE", %r{^/users/sign_out$} ]
     ]
     jwt.expiration_time = 1.day.to_i
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [ :http_auth ]
+  config.skip_session_storage = [:http_auth, :params_auth]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX

--- a/config/initializers/devise_respond_to_json.rb
+++ b/config/initializers/devise_respond_to_json.rb
@@ -1,0 +1,3 @@
+Rails.application.config.to_prepare do
+  DeviseController.respond_to :json
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, key: "_support_platform_api_session"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
   post "/graphql", to: "graphql#execute"
-  devise_for :users
+
+  devise_for :users,
+    controllers: {
+      sessions: "api/users/sessions",
+      registrations: "api/users/registrations",
+      confirmations: "api/users/confirmations"
+    }
 
   get "/tickets/export.csv", to: "exports#tickets_csv"
 

--- a/db/migrate/20250520001445_add_confirmable_to_users.rb
+++ b/db/migrate/20250520001445_add_confirmable_to_users.rb
@@ -1,0 +1,10 @@
+class AddConfirmableToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_14_092426) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_20_001445) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_catalog.plpgsql"
+  enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -72,6 +72,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_14_092426) do
     t.datetime "updated_at", null: false
     t.integer "role", default: 0, null: false
     t.string "name"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## Implement JWT-based Authentication and Custom Devise Controllers for API Users

### Description:
This PR introduces and configures JWT-based authentication for the API using Devise, along with custom Sessions, Registrations, and Confirmations controllers under the Api::Users namespace. It also updates the application structure and routing to align with a token-based authentication flow suited for my frontend Ember.js.

#### Key Changes:
**Authentication Setup**

- Configured Devise to use :jwt_authenticatable with Devise::JWT.

- JWT secret key securely loaded from environment via Dotenv.

**Custom Controllers**

- Api::Users::RegistrationsController:

- Customized respond_with to return user details in JSON after registration.

- Api::Users::SessionsController:

- Overrides create to manually authenticate, sign in, and return JWT + user payload.

- Api::Users::ConfirmationsController:

- Confirms user via token and returns JSON response.


**User Model Update**
- Included necessary Devise modules:
:database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :confirmable, :jwt_authenticatable
